### PR TITLE
Potential fix for code scanning alert no. 5: Type confusion through parameter tampering

### DIFF
--- a/src/routes/jira.js
+++ b/src/routes/jira.js
@@ -14,6 +14,20 @@ const auth = btoa(`${emailJira}:${tokenJira}`);
 router.post("/processarAlertas", async (req, res) => {
   const alertas = req.body;
 
+  if (!Array.isArray(alertas) || !alertas.every((alerta) =>
+    alerta &&
+    typeof alerta === "object" &&
+    typeof alerta.numero_serie === "string" &&
+    typeof alerta.componente === "string" &&
+    typeof alerta.hospital === "string" &&
+    typeof alerta.area === "string" &&
+    typeof alerta.valor_lido === "number" &&
+    typeof alerta.max_permitido === "number" &&
+    typeof alerta.min_permitido === "number"
+  )) {
+    return res.status(400).json({ erro: "Formato inválido de alertas" });
+  }
+
   try {
     const jiraResponse = await fetch(`https://${dominioJira}/rest/api/3/search/jql`, {
       method: "POST",


### PR DESCRIPTION
Potential fix for [https://github.com/ZephyrusPI/Web-Site_Zephyrus/security/code-scanning/5](https://github.com/ZephyrusPI/Web-Site_Zephyrus/security/code-scanning/5)

A correção é validar o tipo em runtime logo após ler `req.body`, rejeitando qualquer payload que não seja um array de objetos com os campos esperados em tipos seguros.  
Melhor abordagem sem alterar funcionalidade: em `src/routes/jira.js`, dentro da rota `POST /processarAlertas`, adicionar uma guarda com `Array.isArray(alertas)` e validar cada item minimamente (objeto não nulo e campos usados no código). Se inválido, retornar `400` com mensagem de erro. Isso elimina a confusão de tipos apontada no `alertas.length` e no loop de processamento, mantendo o comportamento para entradas válidas.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
